### PR TITLE
Allow providing worker source directly in register function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -303,6 +303,9 @@ class ServiceWorker extends events.EventEmitter {
     }
 
     _getWorkerSource(options) {
+        if (this._options._source) {
+            return Promise.resolve(this._options._source);
+        }
         if (/^https?:\/\//.test(this.scriptURL)) {
             return fetch(this.scriptURL)
                 .then(res => res.text());

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,20 @@ module.exports = {
                                     'ms/iter'));
                 });
 
+        },
+        "Allows you to manually provide worker source": function() {
+            const testJS = "var test = 'hello!';";
+            const container = new ServiceWorkerContainer();
+            return container
+                .register('https://www.example.com', {scope: '/', _source: testJS})
+                .then((reg) => {
+                    return reg.active._getWorkerSource()
+                })
+                .then((source) => {
+                    if (source !== testJS) {
+                        throw new Error("JS doesn't match what was provided")
+                    }
+                })
         }
     }
 };


### PR DESCRIPTION
Hello! I've been working on [an implementation](https://github.com/gdnmobilelab/node-service-worker) myself but it looks like yours is a lot better put together than mine, so I might have a few pull requests coming your way.

First off - manually providing the JS source of a worker. I'm using this as part of a build script to bake out templates, so the JS isn't actually available online at the time the worker runs. I've added the ability to provide a `_source` option in the `register()` function, shortcutting the fetch to get the remote JS.

I've added a quick test for it too - let me know what you think.